### PR TITLE
fix: 有時會因為 session 過期撞到 HTTP 500 的 error handling

### DIFF
--- a/fileDiff.py
+++ b/fileDiff.py
@@ -51,6 +51,12 @@ def curlDepartmentCourseTable(year):
 
     # 取得 所有課程的 csv
     response = session.get('https://ccweb.ncnu.edu.tw/student/aspmaker_course_opened_detail_viewlist.php?export=csv')
+
+    # 遇到太短的請求可能是因為 cookie 失效，要重新取 session，正常的有 636746 bytes
+    if len(response.content) < 500000:
+        gotSession = 0
+        return "error"
+
     curlTime = time.strftime("%Y%m%d_%H%M%S")
     print("取得所有課程資料：", curlTime)
     
@@ -62,8 +68,8 @@ if __name__ == "__main__":
     prevAns = curlDepartmentCourseTable("1101")
     while True:
         newAns = curlDepartmentCourseTable("1101")
-
-        if newAns != prevAns:
+        
+        if gotSession and (newAns != prevAns):
             for courseID in newAns:
                 curCourse = newAns[courseID]
                 if prevAns[courseID]['chosen'] != curCourse['chosen']:


### PR DESCRIPTION
## 正常狀況
```
url = 'https://ccweb.ncnu.edu.tw/student/aspmaker_course_opened_detail_viewlist.php?cmd=search&t=aspmaker_course_opened_detail_view&z_year=%3D&x_year={}&z_courseid=%3D&x_courseid=&z_cname=LIKE&x_cname=&z_deptid=%3D&x_deptid=&z_division=LIKE&x_division=&z_grade=%3D&x_grade=&z_teachers=LIKE&x_teachers=&z_not_accessible=LIKE&x_not_accessible='
response = session.get(url.format(1101))
```
有先用以上方法取得 session 之後再做：
```
response = session.get('https://ccweb.ncnu.edu.tw/student/aspmaker_course_opened_detail_viewlist.php?export=csv')
len(response.content)
```
輸出結果是 636746 bytes，content 內容正常。

## 異常狀況 1
清空 jupyter notebook 環境後，若無先取得 session，直接：
```
response = session.get('https://ccweb.ncnu.edu.tw/student/aspmaker_course_opened_detail_viewlist.php?export=csv')
len(response.content)
```
輸出結果僅有 259 bytes，content 僅有：
```
'\ufeff"學期","課號","班別","中文課名","開課系所代碼","開課系所","部別","年級","開課教師","地點","全英語授課","非無障礙教室","英文課名","時間","學分數","人數上限","選修人數","核心能力","職涯類別"\r\n'
```

## 異常狀況 2
若連續抓了約半小時，都沒再拿 session，有機會遇到抓到的內容是：
```
'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml">\n<head>\n<meta http-equiv="Content-Type" content="text/html; charset=big5"/>\n<title>500 - 內部伺服器錯誤。</title>\n<style type="text/css">\n<!--\nbody{margin:0;font-size:.7em;font-family:Verdana, Arial, Helvetica, sans-serif;background:#EEEEEE;}\nfieldset{padding:0 15px 10px 15px;} \nh1{font-size:2.4em;margin:0;color:#FFF;}\nh2{font-size:1.7em;margin:0;color:#CC0000;} \nh3{font-size:1.2em;margin:10px 0 0 0;color:#000000;} \n#header{width:96%;margin:0 0 0 0;padding:6px 2% 6px 2%;font-family:"trebuchet MS", Verdana, sans-serif;color:#FFF;\nbackground-color:#555555;}\n#content{margin:0 0 0 2%;position:relative;}\n.content-container{background:#FFF;width:96%;margin-top:9px;padding:10px;position:relative;}\n-->\n</style>\n</head>\n<body>\n<div id="header"><h1>伺服器錯誤</h1></div>\n<div id="content">\n <div class="content-container"><fieldset>\n  <h2>500 - 內部伺服器錯誤。</h2>\n  <h3>您要尋找的資源有問題而無法顯示。</h3>\n </fieldset></div>\n</div>\n</body>\n</html>\n'
```
總共僅 1135 bytes。且此內容是以 Big5 編碼，用 Python encoding 預設 UTF-8 方式讀會跳 exception。